### PR TITLE
Ensure reservation audits include user and entity IDs

### DIFF
--- a/src/modules/reservas/reserva.controller.ts
+++ b/src/modules/reservas/reserva.controller.ts
@@ -7,7 +7,8 @@ export class ReservaController {
   crearReserva = async (req: Request, res: Response) => {
     try {
       const { personaId, disponibilidadId, fechaHora } = req.body;
-      const reserva = await this.service.crearReserva({ personaId, disponibilidadId, fechaHora });
+      const usuarioId = (req as any).usuario?.id;
+      const reserva = await this.service.crearReserva({ personaId, disponibilidadId, fechaHora, usuarioId });
       res.status(201).json(reserva);
     } catch (error: any) {
       res.status(400).json({ error: error.message });
@@ -16,7 +17,8 @@ export class ReservaController {
 
   confirmarReserva = async (req: Request, res: Response) => {
     try {
-      const result = await this.service.confirmarReserva(req.params.id);
+      const usuarioId = (req as any).usuario?.id;
+      const result = await this.service.confirmarReserva(req.params.id, usuarioId);
       res.status(200).json(result);
     } catch (error: any) {
       res.status(400).json({ error: error.message });
@@ -25,7 +27,8 @@ export class ReservaController {
 
   cancelarReserva = async (req: Request, res: Response) => {
     try {
-      const result = await this.service.cancelarReserva(req.params.id);
+      const usuarioId = (req as any).usuario?.id;
+      const result = await this.service.cancelarReserva(req.params.id, usuarioId);
       res.status(200).json(result);
     } catch (error: any) {
       res.status(400).json({ error: error.message });

--- a/src/modules/reservas/reserva.service.ts
+++ b/src/modules/reservas/reserva.service.ts
@@ -16,8 +16,9 @@ export class ReservaService {
     personaId: string;
     disponibilidadId: string;
     fechaHora: string;
+    usuarioId: string;
   }) {
-    const { personaId, disponibilidadId, fechaHora } = dto;
+    const { personaId, disponibilidadId, fechaHora, usuarioId } = dto;
 
     const persona = await personaRepo.findOne({ where: { id: personaId } });
     if (!persona) throw new Error('Persona no encontrada');
@@ -59,19 +60,22 @@ export class ReservaService {
       disponibilidad
     });
 
+    const creada = await reservaRepo.save(reserva);
+
     await auditoriaRepo.save(
       auditoriaRepo.create({
+        usuario: { id: usuarioId } as any,
         accion: 'crear_reserva',
         descripcion: `Persona ${persona.nombre} ${persona.apellido} creó una reserva en cancha ${disponibilidad.cancha.nombre}`,
         entidad: 'reserva',
-        entidadId: reserva.id
+        entidadId: creada.id
       })
     );
 
-    return await reservaRepo.save(reserva);
+    return creada;
   }
 
-  async confirmarReserva(id: string) {
+  async confirmarReserva(id: string, usuarioId: string) {
     const reserva = await reservaRepo.findOne({
       where: { id },
       relations: ['persona', 'disponibilidad', 'disponibilidad.cancha']
@@ -84,17 +88,18 @@ export class ReservaService {
 
     await auditoriaRepo.save(
       auditoriaRepo.create({
+        usuario: { id: usuarioId } as any,
         accion: 'confirmar_reserva',
         descripcion: `Reserva confirmada por ${reserva.persona.nombre} ${reserva.persona.apellido} en cancha ${reserva.disponibilidad.cancha.nombre}`,
         entidad: 'reserva',
-        entidadId: reserva.id
+        entidadId: actualizada.id
       })
     );
 
     return actualizada;
   }
 
-  async cancelarReserva(id: string) {
+  async cancelarReserva(id: string, usuarioId: string) {
     const reserva = await reservaRepo.findOne({
       where: { id },
       relations: ['persona', 'disponibilidad', 'disponibilidad.cancha']
@@ -107,10 +112,11 @@ export class ReservaService {
 
     await auditoriaRepo.save(
       auditoriaRepo.create({
+        usuario: { id: usuarioId } as any,
         accion: 'cancelar_reserva',
         descripcion: `Reserva cancelada por ${reserva.persona.nombre} ${reserva.persona.apellido} en cancha ${reserva.disponibilidad.cancha.nombre}`,
         entidad: 'reserva',
-        entidadId: reserva.id
+        entidadId: actualizada.id
       })
     );
 


### PR DESCRIPTION
## Summary
- Save reservations before auditing so generated IDs are available
- Register audit entries with user and entity IDs for create/confirm/cancel
- Pass authenticated user ID from controller to service

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a4928df664832eb8b4105471df374d