### PR TITLE
refactor: use AuditoriaService in reserva service

### DIFF
--- a/src/modules/reservas/reserva.service.ts
+++ b/src/modules/reservas/reserva.service.ts
@@ -2,14 +2,14 @@ import { AppDataSource } from '../../database/data-source';
 import { Reserva, EstadoReserva } from '../../entities/Reserva.entity';
 import { Persona } from '../../entities/Persona.entity';
 import { Deuda } from '../../entities/Deuda.entity';
-import { Auditoria } from '../../entities/Auditoria.entity';
 import { DisponibilidadHorario } from '../../entities/DisponibilidadHorario.entity';
+import { AuditoriaService } from '../auditoria/auditoria.service';
 
 const reservaRepo = AppDataSource.getRepository(Reserva);
 const personaRepo = AppDataSource.getRepository(Persona);
 const deudaRepo = AppDataSource.getRepository(Deuda);
 const disponibilidadRepo = AppDataSource.getRepository(DisponibilidadHorario);
-const auditoriaRepo = AppDataSource.getRepository(Auditoria);
+const auditoriaService = new AuditoriaService();
 
 export class ReservaService {
   async crearReserva(dto: {
@@ -62,15 +62,13 @@ export class ReservaService {
 
     const creada = await reservaRepo.save(reserva);
 
-    await auditoriaRepo.save(
-      auditoriaRepo.create({
-        usuario: { id: usuarioId } as any,
-        accion: 'crear_reserva',
-        descripcion: `Persona ${persona.nombre} ${persona.apellido} creó una reserva en cancha ${disponibilidad.cancha.nombre}`,
-        entidad: 'reserva',
-        entidadId: creada.id
-      })
-    );
+    await auditoriaService.registrar({
+      usuarioId,
+      accion: 'crear_reserva',
+      descripcion: `Persona ${persona.nombre} ${persona.apellido} creó una reserva en cancha ${disponibilidad.cancha.nombre}`,
+      entidad: 'reserva',
+      entidadId: creada.id
+    });
 
     return creada;
   }
@@ -86,15 +84,13 @@ export class ReservaService {
     reserva.estado = EstadoReserva.Confirmada;
     const actualizada = await reservaRepo.save(reserva);
 
-    await auditoriaRepo.save(
-      auditoriaRepo.create({
-        usuario: { id: usuarioId } as any,
-        accion: 'confirmar_reserva',
-        descripcion: `Reserva confirmada por ${reserva.persona.nombre} ${reserva.persona.apellido} en cancha ${reserva.disponibilidad.cancha.nombre}`,
-        entidad: 'reserva',
-        entidadId: actualizada.id
-      })
-    );
+    await auditoriaService.registrar({
+      usuarioId,
+      accion: 'confirmar_reserva',
+      descripcion: `Reserva confirmada por ${reserva.persona.nombre} ${reserva.persona.apellido} en cancha ${reserva.disponibilidad.cancha.nombre}`,
+      entidad: 'reserva',
+      entidadId: actualizada.id
+    });
 
     return actualizada;
   }
@@ -110,15 +106,13 @@ export class ReservaService {
     reserva.estado = EstadoReserva.Cancelada;
     const actualizada = await reservaRepo.save(reserva);
 
-    await auditoriaRepo.save(
-      auditoriaRepo.create({
-        usuario: { id: usuarioId } as any,
-        accion: 'cancelar_reserva',
-        descripcion: `Reserva cancelada por ${reserva.persona.nombre} ${reserva.persona.apellido} en cancha ${reserva.disponibilidad.cancha.nombre}`,
-        entidad: 'reserva',
-        entidadId: actualizada.id
-      })
-    );
+    await auditoriaService.registrar({
+      usuarioId,
+      accion: 'cancelar_reserva',
+      descripcion: `Reserva cancelada por ${reserva.persona.nombre} ${reserva.persona.apellido} en cancha ${reserva.disponibilidad.cancha.nombre}`,
+      entidad: 'reserva',
+      entidadId: actualizada.id
+    });
 
     return actualizada;
   }


### PR DESCRIPTION
## Summary
- use AuditoriaService to record reserva actions
- remove direct repository saves for auditoria entries

## Testing
- `npx jest` *(fails: CannotExecuteNotConnectedError: Cannot execute operation on "default" connection because connection is not yet established.)*

------
https://chatgpt.com/codex/tasks/task_e_68a49b6f7c60832e86ea2883ebdb5ab8