### PR TITLE
feat: add central logger

### DIFF
--- a/scripts/generateSwagger.ts
+++ b/scripts/generateSwagger.ts
@@ -1,24 +1,25 @@
-import fs from "fs";
-import path from "path";
+import fs from 'fs';
+import path from 'path';
+import logger from '../src/utils/logger';
 
-const mainSwaggerPath = path.join(__dirname, "../docs/swagger.json");
-const pathsDir = path.join(__dirname, "../docs/paths");
-const outputSwaggerPath = path.join(__dirname, "../docs/swagger.generated.json");
+const mainSwaggerPath = path.join(__dirname, '../docs/swagger.json');
+const pathsDir = path.join(__dirname, '../docs/paths');
+const outputSwaggerPath = path.join(__dirname, '../docs/swagger.generated.json');
 
-console.log("📄 Leyendo swagger base...");
-const swagger = JSON.parse(fs.readFileSync(mainSwaggerPath, "utf-8"));
+logger.info('📄 Leyendo swagger base...');
+const swagger = JSON.parse(fs.readFileSync(mainSwaggerPath, 'utf-8'));
 
 swagger.paths = {};
 
-console.log("🔍 Buscando archivos de paths...");
+logger.info('🔍 Buscando archivos de paths...');
 const files = fs.readdirSync(pathsDir);
 
 files.forEach(file => {
   const filePath = path.join(pathsDir, file);
-  console.log(`➡️  Agregando: ${file}`);
-  const content = JSON.parse(fs.readFileSync(filePath, "utf-8"));
+  logger.info(`➡️  Agregando: ${file}`);
+  const content = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
   Object.assign(swagger.paths, content);
 });
 
 fs.writeFileSync(outputSwaggerPath, JSON.stringify(swagger, null, 2));
-console.log("✅ Swagger generado en docs/swagger.generated.json");
+logger.info('✅ Swagger generado en docs/swagger.generated.json');

--- a/src/database/data-source.ts
+++ b/src/database/data-source.ts
@@ -3,29 +3,29 @@ import { DataSource } from 'typeorm';
 import dotenv from 'dotenv';
 import fs from 'fs';
 import path from 'path';
+import logger from '../utils/logger';
 
 dotenv.config();
 
 const isNotProduction = process.env.NODE_ENV !== 'production';
-// TODO: Replace console.* with centralized logger once utils/logger.ts is implemented
 if (isNotProduction) {
-  console.log("🧭 __dirname =", __dirname);
+  logger.info('🧭 __dirname =', __dirname);
 }
 
 const entitiesDir = path.join(__dirname, '../entities');
 if (isNotProduction) {
-  console.log("🗂️ Buscando archivos en:", entitiesDir);
+  logger.info('🗂️ Buscando archivos en:', entitiesDir);
 }
 
 try {
   const files = fs.readdirSync(entitiesDir);
   const entityFiles = files.filter(f => f.endsWith('.entity.js') || f.endsWith('.entity.ts'));
   if (isNotProduction) {
-    console.log("🔍 Entidades encontradas:", entityFiles);
+    logger.info('🔍 Entidades encontradas:', entityFiles);
   }
 } catch (error) {
   if (isNotProduction) {
-    console.error("❌ Error leyendo carpeta de entidades:", error);
+    logger.error('❌ Error leyendo carpeta de entidades:', error);
   }
 }
 export const AppDataSource = new DataSource({

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,16 +1,17 @@
 import { AppDataSource } from './database/data-source';
 import app from './app';
+import logger from './utils/logger';
 
 const PORT = parseInt(process.env.PORT || '3000', 10);
 
 AppDataSource.initialize()
   .then(() => {
-    console.log('📦 Conexión a PostgreSQL establecida');
+    logger.info('📦 Conexión a PostgreSQL establecida');
     app.listen(PORT, '0.0.0.0', () => {
-      console.log(`🚀 Servidor corriendo en http://localhost:${PORT}`);
+      logger.info(`🚀 Servidor corriendo en http://localhost:${PORT}`);
     });
   })
   .catch((error) => {
-    console.error('❌ Error al inicializar la base de datos:', error);
+    logger.error('❌ Error al inicializar la base de datos:', error);
     process.exit(1);
   });

--- a/src/middlewares/error.middleware.ts
+++ b/src/middlewares/error.middleware.ts
@@ -1,4 +1,5 @@
 import { Request, Response, NextFunction } from 'express';
+import logger from '../utils/logger';
 
 export const errorHandler = (
   err: any,
@@ -6,7 +7,7 @@ export const errorHandler = (
   res: Response,
   _next: NextFunction
 ) => {
-  console.error('Error:', err);
+  logger.error('Error:', err);
 
   const status = err.statusCode || 500;
   const mensaje = err.message || 'Error interno del servidor';

--- a/src/scripts/seed.ts
+++ b/src/scripts/seed.ts
@@ -13,10 +13,11 @@ import { Reserva, EstadoReserva } from '../entities/Reserva.entity';
 import { Desafio, EstadoDesafio } from '../entities/Desafio.entity';
 import { Deuda } from '../entities/Deuda.entity';
 import { Valoracion } from '../entities/Valoracion.entity';
+import logger from '../utils/logger';
 
 (async () => {
   await AppDataSource.initialize();
-  console.log('🌱 Ejecutando seed de datos iniciales...');
+  logger.info('🌱 Ejecutando seed de datos iniciales...');
 
   const rolRepo = AppDataSource.getRepository(Rol);
   const personaRepo = AppDataSource.getRepository(Persona);
@@ -37,7 +38,7 @@ import { Valoracion } from '../entities/Valoracion.entity';
     const existe = await rolRepo.findOneBy({ nombre });
     if (!existe) await rolRepo.save(rolRepo.create({ nombre }));
   }
-  console.log('✅ Roles creados');
+  logger.info('✅ Roles creados');
 
   const crearUsuarioConPerfil = async (nombre: string, apellido: string, email: string, password: string, rolNombre: string, ranking: number) => {
     const personaExistente = await personaRepo.findOneBy({ email });
@@ -54,14 +55,14 @@ import { Valoracion } from '../entities/Valoracion.entity';
   await crearUsuarioConPerfil('Juan', 'Pérez', 'usuario@canchaya.com', 'usuario123', 'usuario', 1000);
   await crearUsuarioConPerfil('Marta', 'Gómez', 'marta@gmail.com', 'marta123', 'usuario', 1100);
   await crearUsuarioConPerfil('Pedro', 'López', 'pedro@gmail.com', 'pedro123', 'usuario', 1050);
-  console.log('👥 Usuarios y perfiles creados');
+  logger.info('👥 Usuarios y perfiles creados');
 
   const deportes = ['f5', 'f7', 'f11', 'padel'];
   for (const nombre of deportes) {
     const existe = await deporteRepo.findOneBy({ nombre });
     if (!existe) await deporteRepo.save(deporteRepo.create({ nombre }));
   }
-  console.log('🏅 Deportes cargados');
+  logger.info('🏅 Deportes cargados');
 
   for (let hora = 18; hora <= 23; hora++) {
     const horaInicio = `${hora.toString().padStart(2, '0')}:00`;
@@ -69,7 +70,7 @@ import { Valoracion } from '../entities/Valoracion.entity';
     const existe = await horarioRepo.findOneBy({ horaInicio });
     if (!existe) await horarioRepo.save(horarioRepo.create({ horaInicio, horaFin }));
   }
-  console.log('⏰ Horarios creados');
+  logger.info('⏰ Horarios creados');
 
   let club = await clubRepo.findOneBy({ nombre: 'Club Central' });
   if (!club) club = await clubRepo.save(clubRepo.create({
@@ -99,7 +100,7 @@ import { Valoracion } from '../entities/Valoracion.entity';
       if (!existe) await disponibilidadRepo.save(disponibilidadRepo.create({ cancha, horario, diaSemana: dia }));
     }
   }
-  console.log('📅 Disponibilidades creadas');
+  logger.info('📅 Disponibilidades creadas');
 
   const usuarios = await usuarioRepo.find({ where: {}, relations: ['persona'] });
   const usuario1 = usuarios.find(u => u.persona.email === 'usuario@canchaya.com');
@@ -152,7 +153,7 @@ import { Valoracion } from '../entities/Valoracion.entity';
     }
   }
 
-  console.log('✅ Seed completo');
+  logger.info('✅ Seed completo');
   process.exit(0);
 })();
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,16 +1,17 @@
 import { AppDataSource } from './database/data-source';
 import app from './app';
+import logger from './utils/logger';
 
 const PORT = parseInt(process.env.PORT || '3000', 10);
 
 AppDataSource.initialize()
   .then(() => {
-    console.log('📦 Conexión a PostgreSQL establecida');
+    logger.info('📦 Conexión a PostgreSQL establecida');
     app.listen(PORT, '0.0.0.0', () => {
-      console.log(`🚀 Servidor corriendo en http://localhost:${PORT}`);
+      logger.info(`🚀 Servidor corriendo en http://localhost:${PORT}`);
     });
   })
   .catch((error) => {
-    console.error('❌ Error al inicializar la base de datos:', error);
+    logger.error('❌ Error al inicializar la base de datos:', error);
     process.exit(1);
   });

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,0 +1,24 @@
+type LogFn = (...args: unknown[]) => void;
+
+let baseLogger: Record<'info' | 'error' | 'warn' | 'debug', LogFn>;
+
+try {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  // @ts-ignore
+  const pino = require('pino');
+  baseLogger = pino();
+} catch {
+  baseLogger = {
+    info: console.log.bind(console),
+    error: console.error.bind(console),
+    warn: console.warn.bind(console),
+    debug: console.debug.bind(console),
+  };
+}
+
+export const info: LogFn = (...args) => baseLogger.info(...args);
+export const error: LogFn = (...args) => baseLogger.error(...args);
+export const warn: LogFn = (...args) => baseLogger.warn(...args);
+export const debug: LogFn = (...args) => baseLogger.debug(...args);
+
+export default { info, error, warn, debug };


### PR DESCRIPTION
## Summary
- add centralized logger utility
- route logs through logger instead of direct console usage

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx jest` *(fails: CannotExecuteNotConnectedError: Cannot execute operation on "default" connection because connection is not yet established.)*

------
https://chatgpt.com/codex/tasks/task_e_68a4aeff9050832eaceb5cef5eead6a6